### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/wordgap-server/wordgap/tools.py
+++ b/wordgap-server/wordgap/tools.py
@@ -26,7 +26,7 @@ try:
 except: 
     print("Kann Tagger nicht laden!")        
 finally:
-    if fh != None:
+    if fh is not None:
         fh.close()
 # tokenizer is loaded on import for performance reasons 
 tokenizer = nltk.data.load('tokenizers/punkt/english.pickle')

--- a/wordgap-server/wordgap/wordex.py
+++ b/wordgap-server/wordgap/wordex.py
@@ -73,7 +73,7 @@ def create_ex(text, pos='n', last_index=False, fast=False):
         dis = tools.get_dis(chosen, pos, lemmas_in_order_of_frequency, fast=fast)
 
         # Wenn keine gueltigen Distraktoren gefunden werden koennen, Satz auslassen 
-        if dis == None:
+        if dis is None:
             s = re.sub(r, "", " ".join(s))
             sents_with_cloze[i].append(s)
             continue


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SuzanaK:wordgap?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:SuzanaK:wordgap?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)