### PR TITLE
Fix "Prefer `format()` over string interpolation operator" issue

### DIFF
--- a/wordgap-server/wordgap/views.py
+++ b/wordgap-server/wordgap/views.py
@@ -186,7 +186,7 @@ def result(request):
         sek = duration.seconds
         stunden, rest = divmod(sek, 3600)
         minuten, sek = divmod(rest, 60)
-        print '%sentence:%sentence:%sentence' % (stunden, minuten, sek)
+        print '{0!s}entence:{1!s}entence:{2!s}entence'.format(stunden, minuten, sek)
 
 
     if request.session.get("right"):


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Prefer `format()` over string interpolation operator](https://www.quantifiedcode.com/app/issue_class/4ACGxFj1)
Issue details: [https://www.quantifiedcode.com/app/project/gh:SuzanaK:wordgap?groups=code_patterns/%3A4ACGxFj1](https://www.quantifiedcode.com/app/project/gh:SuzanaK:wordgap?groups=code_patterns/%3A4ACGxFj1)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)